### PR TITLE
Fix for the Compiling Error with UE4 4.15

### DIFF
--- a/Source/SIOJEditorPlugin/Private/SIOJ_BreakJson.cpp
+++ b/Source/SIOJEditorPlugin/Private/SIOJ_BreakJson.cpp
@@ -3,7 +3,7 @@
 
 #include "SIOJEditorPluginPrivatePCH.h"
 #include "SIOJ_BreakJson.h"
-
+#include "EdGraphUtilities.h"
 #include "Runtime/Launch/Resources/Version.h"
 
 #define LOCTEXT_NAMESPACE "SIOJ_BreakJson"


### PR DESCRIPTION
\Plugins\socketio-client-ue4\Source\SIOJEditorPlugin\Private\SIOJ_BreakJson.cpp(34): error C2653: 'FEdGraphUtilities': is not a class or namespace name
\Plugins\socketio-client-ue4\Source\SIOJEditorPlugin\Private\SIOJ_BreakJson.cpp(34): error C3861: 'GetNetFromPin': identifier not found
\Plugins\socketio-client-ue4\Source\SIOJEditorPlugin\Private\SIOJ_BreakJson.cpp(121): error C2653: 'FEdGraphUtilities': is not a class or namespace name
\Plugins\socketio-client-ue4\Source\SIOJEditorPlugin\Private\SIOJ_BreakJson.cpp(121): error C3861: 'GetNetFromPin': identifier not found