### PR TITLE
Fixes #46 

### DIFF
--- a/Source/SocketIOClient/Public/SocketIOClient.h
+++ b/Source/SocketIOClient/Public/SocketIOClient.h
@@ -27,7 +27,7 @@ public:
 	*/
 	static inline bool IsAvailable()
 	{
-		return FModuleManager::Get().IsModuleLoaded("LeapMotionC");
+		return FModuleManager::Get().IsModuleLoaded("SocketIOClient");
 	}
 
 	/** 


### PR DESCRIPTION
This fixes Issue #46 - Fixed typo which would make IsAvailable fail if you didn't also have the LeapMotionC plugin integrated.

This fix is technically untested but matches the Epic Games documentation for creating a custom plugin.