### PR TITLE
Fix #47 Undesired Connections

### DIFF
--- a/Source/SocketIOClient/Private/SocketIOClientComponent.cpp
+++ b/Source/SocketIOClient/Private/SocketIOClientComponent.cpp
@@ -23,6 +23,11 @@ void USocketIOClientComponent::InitializeComponent()
 		NativeClient = MakeShareable(new FSocketIONative);
 	}
 
+}
+
+void USocketIOClientComponent::BeginPlay()
+{
+	Super::BeginPlay();
 	if (bShouldAutoConnect)
 	{
 		Connect(AddressAndPort);	//connect to default address

--- a/Source/SocketIOClient/Public/SocketIOClientComponent.h
+++ b/Source/SocketIOClient/Public/SocketIOClientComponent.h
@@ -285,7 +285,8 @@ public:
 
 	virtual void InitializeComponent() override;
 	virtual void UninitializeComponent() override;
-
+	virtual void BeginPlay() override;
+	
 protected:
 
 	bool CallBPFunctionWithResponse(UObject* Target, const FString& FunctionName, TArray<TSharedPtr<FJsonValue>> Response);


### PR DESCRIPTION
Fixes Issue #47 where the component tries to connect automatically on loading in the Editor (ie: via blueprints) instead of only in-game. Simply moves the automatic connect attempt to BeginPlay.