### PR TITLE
Added nullptr checks

### DIFF
--- a/Source/SIOJson/Private/SIOJLibrary.cpp
+++ b/Source/SIOJson/Private/SIOJLibrary.cpp
@@ -79,13 +79,19 @@ TMap<USIOJRequestJSON*, FSIOJCallResponse> USIOJLibrary::RequestMap;
 
 FString USIOJLibrary::Conv_JsonObjectToString(USIOJsonObject* InObject)
 {
+	if(InObject)
 	return InObject->EncodeJson();
+
+	return "";
 }
 
 
 USIOJsonObject* USIOJLibrary::Conv_JsonValueToJsonObject(class USIOJsonValue* InValue)
 {
+	if(InValue)
 	return InValue->AsObject();
+
+	return nullptr;
 }
 
 USIOJsonValue* USIOJLibrary::Conv_ArrayToJsonValue(const TArray<USIOJsonValue*>& InArray)
@@ -136,25 +142,37 @@ USIOJsonValue* USIOJLibrary::Conv_BoolToJsonValue(bool InBool)
 
 int32 USIOJLibrary::Conv_JsonValueToInt(USIOJsonValue* InValue)
 {
+	if(InValue)
 	return (int32)InValue->AsNumber();
+
+	return 0;
 }
 
 
 float USIOJLibrary::Conv_JsonValueToFloat(USIOJsonValue* InValue)
 {
+	if (InValue)
 	return InValue->AsNumber();
+
+	return 0.f;
 }
 
 
 bool USIOJLibrary::Conv_JsonValueToBool(USIOJsonValue* InValue)
 {
+	if (InValue)
 	return InValue->AsBool();
+
+	return false;
 }
 
 
 TArray<uint8> USIOJLibrary::Conv_JsonValueToBytes(USIOJsonValue* InValue)
 {
+	if (InValue)
 	return InValue->AsBinary();
+
+	return TArray<uint8>();
 }
 
 void USIOJLibrary::CallURL(UObject* WorldContextObject, const FString& URL, ESIORequestVerb Verb, ESIORequestContentType ContentType, USIOJsonObject* SIOJJson, const FSIOJCallDelegate& Callback)

--- a/Source/SIOJson/Private/SIOJLibrary.cpp
+++ b/Source/SIOJson/Private/SIOJLibrary.cpp
@@ -80,7 +80,9 @@ TMap<USIOJRequestJSON*, FSIOJCallResponse> USIOJLibrary::RequestMap;
 FString USIOJLibrary::Conv_JsonObjectToString(USIOJsonObject* InObject)
 {
 	if(InObject)
-	return InObject->EncodeJson();
+	{
+		return InObject->EncodeJson();
+	}
 
 	return "";
 }
@@ -89,7 +91,9 @@ FString USIOJLibrary::Conv_JsonObjectToString(USIOJsonObject* InObject)
 USIOJsonObject* USIOJLibrary::Conv_JsonValueToJsonObject(class USIOJsonValue* InValue)
 {
 	if(InValue)
-	return InValue->AsObject();
+	{
+		return InValue->AsObject();
+	}
 
 	return nullptr;
 }
@@ -143,7 +147,9 @@ USIOJsonValue* USIOJLibrary::Conv_BoolToJsonValue(bool InBool)
 int32 USIOJLibrary::Conv_JsonValueToInt(USIOJsonValue* InValue)
 {
 	if(InValue)
-	return (int32)InValue->AsNumber();
+	{
+		return (int32)InValue->AsNumber();
+	}
 
 	return 0;
 }
@@ -152,7 +158,9 @@ int32 USIOJLibrary::Conv_JsonValueToInt(USIOJsonValue* InValue)
 float USIOJLibrary::Conv_JsonValueToFloat(USIOJsonValue* InValue)
 {
 	if (InValue)
-	return InValue->AsNumber();
+	{
+		return InValue->AsNumber();
+	}
 
 	return 0.f;
 }
@@ -161,7 +169,9 @@ float USIOJLibrary::Conv_JsonValueToFloat(USIOJsonValue* InValue)
 bool USIOJLibrary::Conv_JsonValueToBool(USIOJsonValue* InValue)
 {
 	if (InValue)
-	return InValue->AsBool();
+	{
+		return InValue->AsBool();
+	}
 
 	return false;
 }
@@ -170,7 +180,9 @@ bool USIOJLibrary::Conv_JsonValueToBool(USIOJsonValue* InValue)
 TArray<uint8> USIOJLibrary::Conv_JsonValueToBytes(USIOJsonValue* InValue)
 {
 	if (InValue)
-	return InValue->AsBinary();
+	{
+		return InValue->AsBinary();
+	}
 
 	return TArray<uint8>();
 }


### PR DESCRIPTION
Nullptr checks on ->
Conv_JsonObjectToString
Conv_JsonValueToJsonObject
Conv_JsonValueToInt
Conv_JsonValueToFloat
Conv_JsonValueToBool
Conv_JsonValueToBytes

If nullptr fails, return default values. Prevents crashing when passing a nullptr. Potentially add a UE_LOG with verbose logging in case you do pass a nullptr?