### PR TITLE
Updated 4.26 changes to be backwards compatible for 4.25 as well.

### DIFF
--- a/Source/CoreUtility/Private/CUBlueprintLibrary.cpp
+++ b/Source/CoreUtility/Private/CUBlueprintLibrary.cpp
@@ -81,7 +81,7 @@ UTexture2D* UCUBlueprintLibrary::Conv_BytesToTexture(const TArray<uint8>& InByte
 					[UpdateData](FRHICommandList& CommandList)
 				{
 					RHIUpdateTexture2D(
-						((FTextureResource*)UpdateData->Texture2D->Resource)->GetTexture2DRHI(),
+						((FTextureResource*)UpdateData->Texture2D->Resource)->TextureRHI->GetTexture2D(),
 						0,
 						UpdateData->Region,
 						UpdateData->Pitch,
@@ -369,7 +369,7 @@ TFuture<UTexture2D*> UCUBlueprintLibrary::Conv_BytesToTexture_Async(const TArray
 			[UpdateData](FRHICommandList& CommandList)
 		{
 			RHIUpdateTexture2D(
-				((FTextureResource*)UpdateData->Texture2D->Resource)->GetTexture2DRHI(),
+				((FTextureResource*)UpdateData->Texture2D->Resource)->TextureRHI->GetTexture2D(),
 				0,
 				UpdateData->Region,
 				UpdateData->Pitch,

--- a/Source/SIOJson/Public/SIOJRequestJSON.h
+++ b/Source/SIOJson/Public/SIOJRequestJSON.h
@@ -311,6 +311,6 @@ protected:
 	FString CustomVerb;
 
 	/** Request we're currently processing */
-	TSharedRef<IHttpRequest, ESPMode::ThreadSafe> HttpRequest = FHttpModule::Get().CreateRequest();
+	FHttpRequestRef HttpRequest = FHttpModule::Get().CreateRequest();
 
 };


### PR DESCRIPTION
Have tested compilation and execution:
 * 4.25 and 4.26 on Windows.
 * 4.26 on Mac OS Big Sur / XCode 12
